### PR TITLE
Add popup on warning

### DIFF
--- a/src/app/pages/picked-courses-list/picked-courses-list.ts
+++ b/src/app/pages/picked-courses-list/picked-courses-list.ts
@@ -48,7 +48,7 @@ export class PickedCoursesList {
 
 
     if (!allowDuplicates && count > all.length) {
-      console.warn(`Requested ${count} unique tracks, but only ${all.length} available. Limiting to ${all.length}.`);
+      alert(`You requested ${count} unique tracks, but only ${all.length} are available. Picking ${all.length} instead.`);
       count = all.length;
     }
 


### PR DESCRIPTION
This PR replaces console warning with a browser alert() popup when the user requests more unique tracks than are available